### PR TITLE
Enable activesupport <7.1

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 6.1")
+  s.add_dependency("activesupport", ">= 4.2", "< 7.1")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 


### PR DESCRIPTION
Changing the dependency version on Active Support from < 6.1 to < 7.1 to enable further Rails upgrades.