### PR TITLE
Replace URI.encode and decode with default escaping

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -318,7 +318,7 @@ module ActiveShipping
       return false unless @options[:login]
       request = <<-EOF
       <?xml version="1.0" encoding="UTF-8"?>
-      <CarrierPickupAvailabilityRequest USERID="#{URI.encode(@options[:login])}">
+      <CarrierPickupAvailabilityRequest USERID="#{URI::DEFAULT_PARSER.escape(@options[:login])}">
         <FirmName>Shopifolk</FirmName>
         <SuiteOrApt>Suite 0</SuiteOrApt>
         <Address2>18 Fair Ave</Address2>
@@ -684,7 +684,7 @@ module ActiveShipping
     def request_url(action, request, test)
       scheme = USE_SSL[action] ? 'https://' : 'http://'
       host = test ? TEST_DOMAINS[USE_SSL[action]] : LIVE_DOMAIN
-      "#{scheme}#{host}/#{LIVE_RESOURCE}?API=#{API_CODES[action]}&XML=#{URI.encode(request)}"
+      "#{scheme}#{host}/#{LIVE_RESOURCE}?API=#{API_CODES[action]}&XML=#{URI::DEFAULT_PARSER.escape(request)}"
     end
 
     def strip_zip(zip)

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -384,7 +384,7 @@ class USPSTest < ActiveSupport::TestCase
   end
 
   def test_strip_9_digit_zip_codes
-    request = URI.decode(@carrier.send(:build_us_rate_request, package_fixtures[:book], "90210-1234", "123456789"))
+    request = URI::DEFAULT_PARSER.unescape(@carrier.send(:build_us_rate_request, package_fixtures[:book], "90210-1234", "123456789"))
     assert !(request =~ /\>90210-1234\</)
     assert request =~ /\>90210\</
     assert !(request =~ /\>123456789\</)
@@ -392,7 +392,7 @@ class USPSTest < ActiveSupport::TestCase
   end
 
   def test_strip_9_digit_zip_codes_world_rates
-    request = URI.decode(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
+    request = URI::DEFAULT_PARSER.unescape(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
                                         package_fixtures[:book], location_fixtures[:auckland], {}))
     refute_match /\<OriginZip\>90210-1234/, request
     assert_match /\<OriginZip\>90210/, request


### PR DESCRIPTION
Replacing encode and decode functions as they are not supported in ruby 3